### PR TITLE
Import Types from MouseTrap

### DIFF
--- a/src/components/TimeGridScheduler.tsx
+++ b/src/components/TimeGridScheduler.tsx
@@ -20,6 +20,7 @@ import scrollIntoView from 'scroll-into-view-if-needed';
 import { SchedulerContext } from '../context';
 import { useClickAndDrag } from '../hooks/useClickAndDrag';
 import { useMousetrap } from '../hooks/useMousetrap';
+import { ExtendedKeyboardEvent } from 'mousetrap';
 import {
   CellInfo,
   ClassNames,

--- a/src/hooks/useMousetrap.ts
+++ b/src/hooks/useMousetrap.ts
@@ -1,4 +1,4 @@
-import Mousetrap from 'mousetrap';
+import Mousetrap, { ExtendedKeyboardEvent } from 'mousetrap';
 import { useEffect, useRef } from 'react';
 
 /**


### PR DESCRIPTION
When trying to use this package, I get an error because the type ExtendedKeyboardEvent is not imported but used anyway. I propose to import it to solve the issue.